### PR TITLE
fix: Remove stray characters causing SyntaxError at EOF

### DIFF
--- a/smart_shopping_optimizer/optimizer.py
+++ b/smart_shopping_optimizer/optimizer.py
@@ -885,5 +885,3 @@ if __name__ == "__main__":
         time.sleep(1)
 
         print("Exiting Optimizer.")
-
-```


### PR DESCRIPTION
A `SyntaxError: invalid syntax` was reported by you, pointing to line 889, which was beyond the expected end of the `optimizer.py` file. This suggested that stray characters, likely triple backticks from a previous generation step, were appended to the file.

This commit ensures that any such trailing characters are removed, restoring the file to its correct syntax. The core logic of the multi-platform scraping enhancement remains the same as the previous commit.